### PR TITLE
[Scene] Support parsing a sphere from Unity Scene to Compute Shader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@
 # Visual Studio cache directory
 .vs/
 
+# Rider IDE configuration
+.idea/
+
 # Gradle cache directory
 .gradle/
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@
 
 # Rider IDE configuration
 .idea/
+Final Project/Assets/Plugins/Editor/JetBrains.meta
+Final Project/Assets/Plugins/Editor/JetBrains/
 
 # Gradle cache directory
 .gradle/

--- a/Final Project/Assets/Geometry.meta
+++ b/Final Project/Assets/Geometry.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 04302787a4ab6496aa950feea54b23a2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Final Project/Assets/Geometry/RTGeometry.cs
+++ b/Final Project/Assets/Geometry/RTGeometry.cs
@@ -1,0 +1,8 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public abstract class RTGeometry : MonoBehaviour
+{
+    public abstract RTGeometryType GetGeomtryType();
+}

--- a/Final Project/Assets/Geometry/RTGeometry.cs.meta
+++ b/Final Project/Assets/Geometry/RTGeometry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 865ef0ae665264308b8944ab2cdd076f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Final Project/Assets/Geometry/RTGeometryType.cs
+++ b/Final Project/Assets/Geometry/RTGeometryType.cs
@@ -1,0 +1,6 @@
+﻿public enum RTGeometryType
+{
+    Nothing = 0,
+    Sphere = 1,
+    Triangle = 2
+}

--- a/Final Project/Assets/Geometry/RTGeometryType.cs.meta
+++ b/Final Project/Assets/Geometry/RTGeometryType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3226eca228cc54f1f830b30d08491877
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Final Project/Assets/Geometry/RTSphere.cs
+++ b/Final Project/Assets/Geometry/RTSphere.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class RTSphere : RTGeometry
+{
+    [SerializeField] private float m_radius = 1;
+
+
+    public override RTGeometryType GetGeomtryType()
+    {
+        return RTGeometryType.Sphere;
+    }
+
+
+    public float[] GetGeometry()
+    {
+        var center = transform.position;
+        
+        return new float[4]
+        {
+            center.x,
+            center.y,
+            center.z,
+            m_radius
+        };
+    }
+}

--- a/Final Project/Assets/Geometry/RTSphere.cs.meta
+++ b/Final Project/Assets/Geometry/RTSphere.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 952c25a529ccd4e3a99be61e35ac6421
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Final Project/Assets/Plugins.meta
+++ b/Final Project/Assets/Plugins.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 982a9e71a559a4bdca20ba4f140187cb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Final Project/Assets/Plugins/Editor.meta
+++ b/Final Project/Assets/Plugins/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 432dc71ebd3d443b8854548eea1032e5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Final Project/Assets/Plugins/Editor/dummy.txt.meta
+++ b/Final Project/Assets/Plugins/Editor/dummy.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7e79fd31f9a864db393f0545973bdf3a
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Final Project/Assets/RenderPipeline/RayTracing.compute.compute
+++ b/Final Project/Assets/RenderPipeline/RayTracing.compute.compute
@@ -14,6 +14,11 @@ float4x4 _CameraToWorld;
 float4x4 _CameraInverseProjection;
 
 
+// sphere
+int _NumOfSpheres;
+StructuredBuffer<float> _Spheres;
+
+
 struct Ray
 {
     float3 origin;
@@ -125,8 +130,12 @@ void IntersectSphere(Ray ray, inout RayHit bestHit, float4 sphere)
 RayHit Trace(Ray ray)
 {
     RayHit bestHit = CreateRayHit();
-    // Add a floating unit sphere
-       IntersectSphere(ray, bestHit, float4(0, 3.0f, 0, 1.0f));
+
+    if(_NumOfSpheres > 0)
+    {
+        IntersectSphere(ray, bestHit, float4(_Spheres[0], _Spheres[1], _Spheres[2], _Spheres[3]));
+    }
+
     return bestHit;
 }
 

--- a/Final Project/Assets/RenderPipeline/RayTracingRenderPipeline.cs
+++ b/Final Project/Assets/RenderPipeline/RayTracingRenderPipeline.cs
@@ -2,7 +2,10 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Rendering;                // Import Unity stuff related to rendering that is shared by all rendering pipelines
-using UnityEngine.Experimental.Rendering;   // Since SRP is an experimental feature, we have to import it using this namespace
+using UnityEngine.Experimental.Rendering;
+using UnityEngine.SceneManagement;
+
+// Since SRP is an experimental feature, we have to import it using this namespace
 
 public class RayTracingRenderPipeline : RenderPipeline
 {
@@ -10,6 +13,8 @@ public class RayTracingRenderPipeline : RenderPipeline
 
     private RenderTexture m_target;         // The texture to hold the ray tracing result from the compute shader
     private Texture m_skyboxTex;            // The skybox we used as the background
+    
+    private List<float[]> m_sphereGeom = new List<float[]>();
 
 
     public RayTracingRenderPipeline(ComputeShader computeShader, Texture skybox)
@@ -29,11 +34,33 @@ public class RayTracingRenderPipeline : RenderPipeline
     {
         base.Render(renderContext, cameras);
 
+        ParseScene(SceneManager.GetActiveScene());
+
         foreach (var camera in cameras)
         {
             RenderPerCamera(renderContext, camera);
         }
     }
+
+
+
+    private void ParseScene(Scene scene)
+    {
+        m_sphereGeom.Clear();
+        
+        GameObject[] roots = scene.GetRootGameObjects();
+
+        foreach (var root in roots)
+        {
+            RTSphereRenderer[] sphereRenderers = root.GetComponentsInChildren<RTSphereRenderer>();
+
+            foreach (var renderer in sphereRenderers)
+            {
+                m_sphereGeom.Add(renderer.GetGeometry());
+            }
+        }
+    }
+    
 
 
     /// <summary>
@@ -57,17 +84,34 @@ public class RayTracingRenderPipeline : RenderPipeline
             ((clearFlags & CameraClearFlags.Depth) != 0),
             ((clearFlags & CameraClearFlags.Color) != 0),
             camera.backgroundColor);
-
+        
+        #endregion
+        
+        
+        #region Ray Tracing
 
         m_computeShader.SetMatrix("_CameraToWorld", camera.cameraToWorldMatrix);
         m_computeShader.SetMatrix("_CameraInverseProjection", camera.projectionMatrix.inverse);
         m_computeShader.SetTexture(0, "_SkyboxTexture", m_skyboxTex);
+        m_computeShader.SetInt("_NumOfSpheres", m_sphereGeom.Count);
+        ComputeBuffer sphereBuffer = null;
+        if (m_sphereGeom.Count > 0)
+        {
+            sphereBuffer = new ComputeBuffer(4, 16);
+            sphereBuffer.SetData(m_sphereGeom[0]);
+            m_computeShader.SetBuffer(0, "_Spheres", sphereBuffer);
+        }
         m_computeShader.SetTexture(0, "Result", m_target);
         int threadGroupsX = Mathf.CeilToInt(Screen.width / 8.0f);
         int threadGroupsY = Mathf.CeilToInt(Screen.height / 8.0f);
         if (threadGroupsX > 0 && threadGroupsY > 0)                 // Prevent dispatching 0 threads to GPU (when the editor is starting or there is no screen to render) 
         {
             m_computeShader.Dispatch(0, threadGroupsX, threadGroupsY, 1);
+        }
+
+        if (sphereBuffer != null)
+        {
+            sphereBuffer.Release();
         }
 
         buffer.Blit(m_target, camera.activeTexture);

--- a/Final Project/Assets/Renderer.meta
+++ b/Final Project/Assets/Renderer.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e8d703c3f9c5f43eda6a352c1449f556
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Final Project/Assets/Renderer/RTRenderer.cs
+++ b/Final Project/Assets/Renderer/RTRenderer.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using UnityEngine;
+
+public class RTRenderer : MonoBehaviour
+{
+    protected RTGeometry m_geom = null;
+
+
+    public RTGeometryType GeometryType
+    {
+        get
+        {
+            if (m_geom == null)
+            {
+                return RTGeometryType.Nothing;
+            }
+
+            return m_geom.GetGeomtryType();
+        }
+    }
+    
+    
+    
+}

--- a/Final Project/Assets/Renderer/RTRenderer.cs.meta
+++ b/Final Project/Assets/Renderer/RTRenderer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 531586c7bf63241bcb1a4687d7d3e714
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Final Project/Assets/Renderer/RTSphereRenderer.cs
+++ b/Final Project/Assets/Renderer/RTSphereRenderer.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[RequireComponent(typeof(RTSphere))]
+public class RTSphereRenderer : RTRenderer
+{
+    private void Awake()
+    {
+        m_geom = GetComponent<RTSphere>();    // Require Component Directive enforce that there must be a RTSphere component 
+    }
+
+
+    public RTSphere mySphere
+    {
+        get
+        {
+            if (m_geom == null)
+            {
+                m_geom = GetComponent<RTSphere>();
+            }
+
+            return (RTSphere)m_geom;
+        }
+    }
+
+
+    public float[] GetGeometry()
+    {
+        if (mySphere == null)
+        {
+            return new float[4]{0, 0, 0, 0};
+        }
+
+        return mySphere.GetGeometry();
+    }
+}

--- a/Final Project/Assets/Renderer/RTSphereRenderer.cs.meta
+++ b/Final Project/Assets/Renderer/RTSphereRenderer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a707b232e61a247379604c2635881a1e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Final Project/Assets/Scenes/SampleScene.unity
+++ b/Final Project/Assets/Scenes/SampleScene.unity
@@ -725,6 +725,63 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1527152220
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1527152223}
+  - component: {fileID: 1527152222}
+  - component: {fileID: 1527152221}
+  m_Layer: 0
+  m_Name: RTSphere Demo 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1527152221
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1527152220}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a707b232e61a247379604c2635881a1e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1527152222
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1527152220}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 952c25a529ccd4e3a99be61e35ac6421, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_radius: 2
+--- !u!4 &1527152223
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1527152220}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1551905935
 GameObject:
   m_ObjectHideFlags: 0

--- a/Final Project/ProjectSettings/EditorSettings.asset
+++ b/Final Project/ProjectSettings/EditorSettings.asset
@@ -8,14 +8,16 @@ EditorSettings:
   m_SerializationMode: 2
   m_LineEndingsForNewScripts: 2
   m_DefaultBehaviorMode: 0
+  m_PrefabRegularEnvironment: {fileID: 0}
+  m_PrefabUIEnvironment: {fileID: 0}
   m_SpritePackerMode: 0
   m_SpritePackerPaddingPower: 1
   m_EtcTextureCompressorBehavior: 1
   m_EtcTextureFastCompressor: 1
   m_EtcTextureNormalCompressor: 2
   m_EtcTextureBestCompressor: 4
-  m_ProjectGenerationIncludedExtensions: txt;xml;fnt;cd
+  m_ProjectGenerationIncludedExtensions: txt;xml;fnt;cd;asmdef
   m_ProjectGenerationRootNamespace: 
-  m_UserGeneratedProjectSuffix: 
   m_CollabEditorSettings:
     inProgressEnabled: 1
+  m_EnableTextureStreamingInPlayMode: 1


### PR DESCRIPTION
The geometry type is stored in RTGeometryType.cs
The geometry base class is RTGeometry.cs
The sphere class is RTSphere.cs. It defines the sphere.

The RTSphereRenderer supports Rendering Pipeline by relaying the sphere information.

The SRP is responsible for setting the sphere data to compute shader.