### PR TITLE
[Materials] Add material parsing, need compute integ

### DIFF
--- a/Final Project/Assets/Extension/Vector3Extension.cs
+++ b/Final Project/Assets/Extension/Vector3Extension.cs
@@ -11,4 +11,9 @@ public static class Vector3Extension
     {
         return new float[]{v.x, v.y, v.z};
     }
+
+    public static int SizeOf()
+    {
+        return sizeof(float) * 3;
+    }
 }

--- a/Final Project/Assets/Geometry/RTSphere.cs
+++ b/Final Project/Assets/Geometry/RTSphere.cs
@@ -5,13 +5,24 @@ using UnityEngine;
 public class RTSphere : RTGeometry
 {
     [SerializeField] private float m_radius = 1;
+    [SerializeField] private string m_materialName;
 
+    private int m_materialIndex = -1;
 
     public override RTGeometryType GetGeometryType()
     {
         return RTGeometryType.Sphere;
     }
 
+    public string GetMaterialName()
+    {
+        return m_materialName;
+    }
+
+    public void SetMaterialIndex(int index)
+    {
+        m_materialIndex = index;
+    }
 
     public RTSphere_t GetGeometry()
     {

--- a/Final Project/Assets/Geometry/RTSphereStructure.cs
+++ b/Final Project/Assets/Geometry/RTSphereStructure.cs
@@ -6,12 +6,15 @@ using UnityEngine;
 /// </summary>
 public struct RTSphere_t
 {
-    public int id;
+    public int id;  // geometryIndex
     public Vector3 center;
     public float radius;
+    public int materialIndex;
 
     public static int GetSize()
     {
-        return sizeof(int) + sizeof(float) * 3 + sizeof(float);
+        return Vector3Extension.SizeOf()
+            + sizeof(int) * 2
+            + sizeof(float);
     }
 }

--- a/Final Project/Assets/Geometry/RTTriangle.cs
+++ b/Final Project/Assets/Geometry/RTTriangle.cs
@@ -11,6 +11,9 @@ public class RTTriangle : RTGeometry
     [SerializeField] private Vector3 m_vertices1 = Vector3.zero;
     [SerializeField] private Vector3 m_vertices2 = Vector3.zero;
     [SerializeField] private bool m_isDoubleSide = true;
+    [SerializeField] private string m_materialName;
+
+    private int m_materialIndex = -1;
 
 
     private Vector4 m_worldVert0 = Vector4.zero;
@@ -27,6 +30,15 @@ public class RTTriangle : RTGeometry
         return RTGeometryType.Triangle;
     }
 
+    public string GetMaterialName()
+    {
+        return m_materialName;
+    }
+
+    public void SetMaterialIndex(int index)
+    {
+        m_materialIndex = index;
+    }
 
     public RTTriangle_t GetGeometry()
     {

--- a/Final Project/Assets/Geometry/RTTriangleStructure.cs
+++ b/Final Project/Assets/Geometry/RTTriangleStructure.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 /// </summary>
 public struct RTTriangle_t
 {
-    public int id;
+    public int id;  // geometryIndex
     public Vector3 vert0;
     public Vector3 vert1;
     public Vector3 vert2;
@@ -14,9 +14,12 @@ public struct RTTriangle_t
     public float planeD;
     public float area;
     public int isDoubleSide;
+    public int materialIndex;
     
     public static int GetSize()
     {
-        return sizeof(int) + sizeof(float) * 14 + sizeof(int);    // (vertices: 3 * 3 = 9) + (normal: 3) + (planeD: 1) + (area: 1)
+        return Vector3Extension.SizeOf() * 4
+            + sizeof(int) * 3
+            + sizeof(float) * 2;
     }
 }

--- a/Final Project/Assets/RenderPipeline/Geometry/RTTriangle.compute
+++ b/Final Project/Assets/RenderPipeline/Geometry/RTTriangle.compute
@@ -14,6 +14,7 @@ struct RTTriangle
     float planeD;
     float area;
     int isDoubleSide;
+    int matIndex;
 };
 
 void IntersectTriangle(Ray ray, inout RayHit bestHit, RTTriangle tri)
@@ -85,6 +86,8 @@ void IntersectTriangle(Ray ray, inout RayHit bestHit, RTTriangle tri)
     {
         bestHit.normal = tri.normal;
     }
+
+    bestHit.matIndex = tri.matIndex;
 }
 
 #endif  // RTTRIANGLE_COMPUTE

--- a/Final Project/Assets/RenderPipeline/RTMaterial.compute
+++ b/Final Project/Assets/RenderPipeline/RTMaterial.compute
@@ -23,20 +23,54 @@ struct RTMaterial
     float3 position;
 };
 
-RTMaterial GetIndexedMaterial(int index,
+RTMaterial GetIndexedMaterial(StructuredBuffer<RTMaterial> materials,
     int numOfMaterials,
-    StructuredBuffer<RTMaterial> materials)
+    int index)
 {
     RTMaterial mat;
 
     // If index valid, then retrieve material
-    // Otherwise, return default material
     if (index >= 0 && index < numOfMaterials)
     {
         mat = materials[index];
     }
+    // Otherwise, return default material
+    // TODO: Specify custom values for default material
+    else
+    {
+        mat.id = -1;
 
-    // TODO: Specify properties for default material
+        // classic Ambient, Diffuse, Specular
+        mat.ka.x = 0.0f;
+        mat.ka.y = 0.0f;
+        mat.ka.z = 0.0f;
+
+        mat.ks.x = 0.0f;
+        mat.ks.y = 0.0f;
+        mat.ks.z = 0.0f;
+
+        mat.kd.x = 0.0f;
+        mat.kd.y = 0.0f;
+        mat.kd.z = 0.0f;
+
+        mat.n = 1.0f;
+
+        // support for transparency and refractiveIndex
+        mat.transparency = 0.0f;
+        mat.refractiveIndex = 0.0f;
+
+        // support for reflection
+        mat.reflectivity = 0.0f;
+
+        // support for normal and positional map
+        mat.normal.x = 0.0f;
+        mat.normal.y = 0.0f;
+        mat.normal.z = 0.0f;
+
+        mat.position.x = 0.0f;
+        mat.position.y = 0.0f;
+        mat.position.z = 0.0f;
+    }
 
     return mat;
 }

--- a/Final Project/Assets/RenderPipeline/RTMaterial.compute
+++ b/Final Project/Assets/RenderPipeline/RTMaterial.compute
@@ -9,7 +9,7 @@ struct RTMaterial
     float3 ka;
     float3 ks;
     float3 kd;
-    float3 n;
+    float n;
 
     // support for transparency and refractiveIndex
     float transparency;
@@ -22,5 +22,23 @@ struct RTMaterial
     float3 normal;
     float3 position;
 };
+
+RTMaterial GetIndexedMaterial(int index,
+    int numOfMaterials,
+    StructuredBuffer<RTMaterial> materials)
+{
+    RTMaterial mat;
+
+    // If index valid, then retrieve material
+    // Otherwise, return default material
+    if (index >= 0 && index < numOfMaterials)
+    {
+        mat = materials[index];
+    }
+
+    // TODO: Specify properties for default material
+
+    return mat;
+}
 
 #endif  // RTMATERIAL_COMPUTE

--- a/Final Project/Assets/RenderPipeline/RTMaterial.compute
+++ b/Final Project/Assets/RenderPipeline/RTMaterial.compute
@@ -1,0 +1,26 @@
+﻿#ifndef RTMATERIAL_COMPUTE
+#define RTMATERIAL_COMPUTE
+
+struct RTMaterial
+{
+    int id;
+
+    // classic Ambient, Diffuse, Specular
+    float3 ka;
+    float3 ks;
+    float3 kd;
+    float3 n;
+
+    // support for transparency and refractiveIndex
+    float transparency;
+    float refractiveIndex; 
+
+    // support for reflection
+    float reflectivity;
+    
+    // support for normal and positional map
+    float3 normal;
+    float3 position;
+};
+
+#endif  // RTMATERIAL_COMPUTE

--- a/Final Project/Assets/RenderPipeline/RTMaterial.compute.meta
+++ b/Final Project/Assets/RenderPipeline/RTMaterial.compute.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 827c0353268769c4aa23b423f0e41b42
+ComputeShaderImporter:
+  externalObjects: {}
+  currentAPIMask: 4
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Final Project/Assets/RenderPipeline/RTSphere.compute
+++ b/Final Project/Assets/RenderPipeline/RTSphere.compute
@@ -9,6 +9,7 @@ struct RTSphere
     int id;
     float3 center;
     float radius;
+    int matIndex;
 };
 
 void IntersectSphere(Ray ray, inout RayHit bestHit, RTSphere sphere)
@@ -77,7 +78,7 @@ void IntersectSphere(Ray ray, inout RayHit bestHit, RTSphere sphere)
         bestHit.geoType = 0;
         bestHit.position = ray.origin + hitDis * ray.direction;
         bestHit.normal = normalize(bestHit.position - sphere.center);
-
+        bestHit.matIndex = sphere.matIndex;
     }
 }
 

--- a/Final Project/Assets/RenderPipeline/RayHit.compute
+++ b/Final Project/Assets/RenderPipeline/RayHit.compute
@@ -13,6 +13,7 @@ struct RayHit
     int geoType;   // 0 is sphere, 1 is triangle
     float3 position;
     float3 normal;
+    int matIndex;
 };
 
 RayHit CreateRayHit()
@@ -24,6 +25,7 @@ RayHit CreateRayHit()
     hit.normal = float3(0.0f, 0.0f, 0.0f);
     hit.geoIndex = -1;
     hit.geoType = -1;
+    hit.matIndex = -1;
     return hit;
 }
 

--- a/Final Project/Assets/RenderPipeline/RayTracing.compute
+++ b/Final Project/Assets/RenderPipeline/RayTracing.compute
@@ -7,6 +7,7 @@
 #include "Light/RTSpotLight_UW.compute"
 #include "RTSphere.compute"
 #include "Geometry/RTTriangle.compute"
+#include "RTMaterial.compute"
 #include "Shading/Phong.compute"
 #include "SecondaryRay/TraceReflection.compute"
 #include "SecondaryRay/Reflection.compute"
@@ -61,6 +62,10 @@ StructuredBuffer<RTSphere> _Spheres;
 // triangle
 int _NumOfTriangles;
 StructuredBuffer<RTTriangle> _Triangles;
+
+// material
+int _NumOfMaterials;
+StructuredBuffer<RTMaterial> _Materials;
 
 
 Ray CreateCameraRay(float2 uv)
@@ -120,7 +125,9 @@ void CSMain (uint3 id : SV_DispatchThreadID)
                           _SpotShadowMap,
                           _ShadowUtility,
                           _FogFactor,
-                          _FogColor);
+                          _FogColor,
+                          _NumOfMaterials,
+                          _Materials);
 
     if(_MaxRayGeneration > 1) {
         float3 refl = Transparent(
@@ -145,7 +152,10 @@ void CSMain (uint3 id : SV_DispatchThreadID)
                         _SpotShadowMap,
                         _ShadowUtility,
                         _FogFactor,
-                        _FogColor);
+                        _FogColor,
+                        _NumOfMaterials,
+                        _Materials
+                        );
                         
         float3 ref2 = Reflection(
                         _MaxRayGeneration,
@@ -169,7 +179,9 @@ void CSMain (uint3 id : SV_DispatchThreadID)
                         _SpotShadowMap,
                         _ShadowUtility,
                         _FogFactor,
-                        _FogColor);             
+                        _FogColor,
+                        _NumOfMaterials,
+                        _Materials);             
         
         result = refl;
     }     

--- a/Final Project/Assets/RenderPipeline/SRP/RayTracingRenderPipeline.cs
+++ b/Final Project/Assets/RenderPipeline/SRP/RayTracingRenderPipeline.cs
@@ -43,6 +43,7 @@ namespace RayTracingRenderer
         private ComputeBuffer m_sphereBuffer;
         private ComputeBuffer m_spotLightBuffer;
         private ComputeBuffer m_triangleBuffer;
+        private ComputeBuffer m_materialBuffer;
         private RenderPipelineConfigObject m_config;
         private RenderTexture m_shadowMap;
         private RenderTexture m_target;
@@ -111,6 +112,7 @@ namespace RayTracingRenderer
                 RunSetShadowMapToMainShader(m_shadowMapList, m_shadowUtilityBuffer);
                 RunSetSpheresToMainShader(m_sphereBuffer, m_sceneParser.GetSpheres().Count);
                 RunSetTrianglesToMainShader(m_triangleBuffer, m_sceneParser.GetTriangles().Count);
+                RunSetMaterialsToMainShader(m_materialBuffer, m_sceneParser.GetMaterials().Count);
                 RunSetDirectionalLightsToMainShader(m_directionalLightBuffer, m_sceneParser.GetDirectionalLights().Count);
                 RunSetPointLightsToMainShader(m_pointLightBuffer, m_sceneParser.GetPointLights().Count);
                 RunSetSpotLightsToMainShader(m_spotLightBuffer, m_sceneParser.GetSpotLights().Count);

--- a/Final Project/Assets/RenderPipeline/SRP/RayTracingRenderPipeline_DataToShader.cs
+++ b/Final Project/Assets/RenderPipeline/SRP/RayTracingRenderPipeline_DataToShader.cs
@@ -10,6 +10,7 @@ namespace RayTracingRenderer
         {
             LoadBufferWithSpheres(sceneParser);
             LoadBufferWithTriangles(sceneParser);
+            LoadBufferWithMaterials(sceneParser);
         }
 
 
@@ -59,6 +60,22 @@ namespace RayTracingRenderer
             }
         }
 
+        private void LoadBufferWithMaterials(SceneParser sceneParser)
+        {
+            int count = sceneParser.GetMaterials().Count;
+            
+            m_materialBuffer?.Release();
+            
+            if (count > 0)
+            {
+                m_materialBuffer = new ComputeBuffer(count, RTMaterial_t.GetSize());
+                m_materialBuffer.SetData(sceneParser.GetMaterials());
+            }
+            else
+            {
+                m_materialBuffer = new ComputeBuffer(1, RTMaterial_t.GetSize());
+            }
+        }
 
         private void LoadBufferWithDirectionalLights(ref ComputeBuffer buffer, SceneParser sceneParser)
         {
@@ -109,6 +126,7 @@ namespace RayTracingRenderer
         {
             m_sphereBuffer.Release();
             m_triangleBuffer.Release();
+            m_materialBuffer.Release();
             m_directionalLightBuffer.Release();
             m_pointLightBuffer.Release();
             m_spotLightBuffer.Release();

--- a/Final Project/Assets/RenderPipeline/SRP/RayTracingRenderPipeline_Render.cs
+++ b/Final Project/Assets/RenderPipeline/SRP/RayTracingRenderPipeline_Render.cs
@@ -116,6 +116,12 @@ namespace RayTracingRenderer
             m_mainShader.SetBuffer(kIndex, "_Spheres", buffer);
         }
 
+        private void RunSetMaterialsToMainShader(ComputeBuffer buffer, int count)
+        {
+            m_mainShader.SetInt("_NumOfMaterials", count);
+            m_mainShader.SetBuffer(kIndex, "_Materials", buffer);
+        }
+
         private void RunSetTrianglesToMainShader(ComputeBuffer buffer, int count)
         {
             m_mainShader.SetInt("_NumOfTriangles", count);

--- a/Final Project/Assets/RenderPipeline/SRP/SceneParser.cs
+++ b/Final Project/Assets/RenderPipeline/SRP/SceneParser.cs
@@ -9,6 +9,7 @@ namespace RayTracingRenderer
     {
         private List<RTSphere_t> m_sphereGeom;
         private List<RTTriangle_t> m_triangleGeom;
+        private List<RTMaterial_t> m_materials;
         private List<RTLightStructureDirectional_t> m_directionalLights;
         private List<RTLightStructurePoint_t> m_pointLights;
         private List<RTLightStructureSpot_t> m_spotLights;
@@ -34,6 +35,11 @@ namespace RayTracingRenderer
             return m_triangleGeom;
         }
         
+        public List<RTMaterial_t> GetMaterials()
+        {
+            return m_materials;
+        }
+        
         public List<RTLightStructureDirectional_t> GetDirectionalLights()
         {
             return m_directionalLights;
@@ -57,12 +63,112 @@ namespace RayTracingRenderer
             int count = 0;
 
             ParseLight(roots);
+            ParseMaterial(roots);
             ParseSphere(roots, ref count);
             ParseTriangle(roots,ref count);
         }
 
+        private void ParseMaterial(GameObject[] roots)
+        {
+            int count = 0;
+
+            // TODO: Optimize dynamic array generation
+            if (m_materials == null)
+            {
+                m_materials = new List<RTMaterial_t>();
+            }
+
+            m_materials.Clear();
+
+            foreach (var root in roots)
+            {
+                RTMaterialDatabase[] materialDatabases 
+                    = root.GetComponentsInChildren<RTMaterialDatabase>();
+
+                foreach (var database in materialDatabases)
+                {
+                    if (database.gameObject.activeSelf)
+                    {
+                        if (database.GetMaterials() == null)
+                        {
+                            continue;
+                        }
+                        
+                        foreach (var mat in database.GetMaterials())
+                        {
+                            string name = mat.GetName();
+                            SetMaterialIndexSpheres(roots, name, count);
+                            SetMaterialIndexTriangles(roots, name, count);
+
+                            RTMaterial_t matStructure = mat.GetMaterial();
+                            matStructure.id = count++;
+                            m_materials.Add(matStructure);
+                        }
+                    }
+                }
+            }
+        }
+
+        private void SetMaterialIndexSpheres(GameObject[] roots,
+            string name, int index)
+        {
+            foreach (var root in roots)
+            {
+                RTSphereRenderer[] sphereRenderers 
+                    = root.GetComponentsInChildren<RTSphereRenderer>();
+
+                foreach (var renderer in sphereRenderers)
+                {
+                    if (renderer.gameObject.activeSelf)
+                    {
+                        string sphereMaterialName
+                            = renderer.GetSphere().GetMaterialName();
+                        if (sphereMaterialName != null)
+                        {
+                            if (sphereMaterialName == name)
+                            {
+                                renderer.GetSphere().SetMaterialIndex(index);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private void SetMaterialIndexTriangles(GameObject[] roots,
+            string name, int index)
+        {
+            foreach (var root in roots)
+            {
+                RTTriangleRenderer[] triangleRenderers 
+                    = root.GetComponentsInChildren<RTTriangleRenderer>();
+
+                foreach (var renderer in triangleRenderers)
+                {
+                    if (renderer.gameObject.activeSelf)
+                    {
+                        string triangleMaterialName
+                            = renderer.GetTriangle().GetMaterialName();
+                        if (triangleMaterialName != null)
+                        {
+                            if(triangleMaterialName == name)
+                            {
+                                renderer.GetTriangle().SetMaterialIndex(index);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         private void ParseSphere(GameObject[] roots, ref int counter)
         {   
+            // Force initialization of dependencies
+            if (m_materials == null)
+            {
+                ParseMaterial(roots);
+            }
+
             // TODO: Optimize dynamic array generation
             m_sphereGeom.Clear();
 
@@ -75,8 +181,7 @@ namespace RayTracingRenderer
                     if (renderer.gameObject.activeSelf)
                     {
                         RTSphere_t sphereGeomT = renderer.GetGeometry();
-                        sphereGeomT.id = counter;
-                        counter++;
+                        sphereGeomT.id = counter++;
                         m_sphereGeom.Add(sphereGeomT);
                     }
                 }
@@ -85,6 +190,12 @@ namespace RayTracingRenderer
 
         private void ParseTriangle(GameObject[] roots, ref int counter)
         {
+            // Force initialization of dependencies
+            if (m_materials == null)
+            {
+                ParseMaterial(roots);
+            }
+
             // TODO: Optimize dynamic array generation
             if (m_triangleGeom == null)
             {
@@ -102,14 +213,12 @@ namespace RayTracingRenderer
                     if (renderer.gameObject.activeSelf)
                     {
                         RTTriangle_t triangleGeomT = renderer.GetGeometry();
-                        triangleGeomT.id = counter;
-                        counter++;
+                        triangleGeomT.id = counter++;
                         m_triangleGeom.Add(triangleGeomT);
                     }
                 }
             }
         }
-
 
         private void ParseLight(GameObject[] roots)
         {

--- a/Final Project/Assets/RenderPipeline/SecondaryRay/Reflection.compute
+++ b/Final Project/Assets/RenderPipeline/SecondaryRay/Reflection.compute
@@ -22,7 +22,9 @@ float3 Reflection(
     Texture2DArray<float4> shadowMap,
     StructuredBuffer<RTSpotLight_UW> shadowUtility,
     float fogFactor,
-    float3 fogColor)
+    float3 fogColor,
+    int numOfMaterials,
+    StructuredBuffer<RTMaterial> materials)
 {
     // Hard code
     // Request parser to add 
@@ -117,7 +119,9 @@ float3 Reflection(
                                 shadowMap,
                                 shadowUtility,
                                 fogFactor,
-                                fogColor);
+                                fogColor,
+                                numOfMaterials,
+                                materials);
                  colorArr[i] += color;    
              }     
             return colorArr[1] + (colorArr[0] * k); 
@@ -183,7 +187,9 @@ float3 Reflection(
                                 shadowMap,
                                 shadowUtility,
                                 fogFactor,
-                                fogColor);
+                                fogColor,
+                                numOfMaterials,
+                                materials);
                  colorArr[i] = color;    
              }     
             return colorArr[3] + ((colorArr[2] + (colorArr[1] * k)) * k); 
@@ -249,7 +255,9 @@ float3 Reflection(
                                 shadowMap,
                                 shadowUtility,
                                 fogFactor,
-                                fogColor);
+                                fogColor,
+                                numOfMaterials,
+                                materials);
                  colorArr[i] = color;    
              }     
             return colorArr[3] + ((colorArr[2] + (colorArr[1] * k)) * k); 

--- a/Final Project/Assets/RenderPipeline/SecondaryRay/Transparent.compute
+++ b/Final Project/Assets/RenderPipeline/SecondaryRay/Transparent.compute
@@ -25,7 +25,9 @@ float3 Transparent(
     Texture2DArray<float4> shadowMap,
     StructuredBuffer<RTSpotLight_UW> shadowUtility,
     float fogFactor,
-    float3 fogColor)
+    float3 fogColor,
+    int numOfMaterials,
+    StructuredBuffer<RTMaterial> materials)
 {
     if (hit.distance < 1.#INF)
     {         
@@ -169,7 +171,9 @@ float3 Transparent(
                                 shadowMap,
                                 shadowUtility,
                                 fogFactor,
-                                fogColor);
+                                fogColor,
+                                numOfMaterials,
+                                materials);
                  colorArr[0] += color;
                  return colorArr[0] + ((1.0003/refIndex) * colorArr[1]);
                 
@@ -237,7 +241,9 @@ float3 Transparent(
                                 shadowMap,
                                 shadowUtility,
                                 fogFactor,
-                                fogColor);
+                                fogColor,
+                                numOfMaterials,
+                                materials);
                      colorArr[i] += color; 
                      --i;
                  }               
@@ -313,7 +319,9 @@ float3 Transparent(
                                 shadowMap,
                                 shadowUtility,
                                 fogFactor,
-                                fogColor);
+                                fogColor,
+                                numOfMaterials,
+                                materials);
                      colorArr[i] += color; 
                      --i;
                  }               
@@ -390,7 +398,9 @@ float3 Transparent(
                                 shadowMap,
                                 shadowUtility,
                                 fogFactor,
-                                fogColor);
+                                fogColor,
+                                numOfMaterials,
+                                materials);
                      colorArr[i] += color; 
                      --i;
                  }               

--- a/Final Project/Assets/RenderPipeline/Shading/Phong.compute
+++ b/Final Project/Assets/RenderPipeline/Shading/Phong.compute
@@ -54,16 +54,9 @@ float3 Shade(
     float hitDistance = hit.distance;
 
     // Example of how to retrieve material info
-    // TODO - Move into utility func
-    float shininess;
-    if (hit.matIndex >= 0 && hit.matIndex < numOfMaterials)
-    {
-        shininess = materials[hit.matIndex].n;
-    }
-    else
-    {
-        shininess = 5;  // default value
-    }
+    RTMaterial mat = GetIndexedMaterial(hit.matIndex,
+        numOfMaterials, materials);
+    float shininess = mat.n;
 
     if (hitDistance < 1.#INF)
     {

--- a/Final Project/Assets/RenderPipeline/Shading/Phong.compute
+++ b/Final Project/Assets/RenderPipeline/Shading/Phong.compute
@@ -46,10 +46,24 @@ float3 Shade(
     Texture2DArray<float4> shadowMap,
     StructuredBuffer<RTSpotLight_UW> shadowUtility,
     float fogFactor,
-    float3 fogColor)
+    float3 fogColor,
+    int numOfMaterials,
+    StructuredBuffer<RTMaterial> materials)
 {
     float3 color = float3(0, 0, 0);
     float hitDistance = hit.distance;
+
+    // Example of how to retrieve material info
+    // TODO - Move into utility func
+    float shininess;
+    if (hit.matIndex >= 0 && hit.matIndex < numOfMaterials)
+    {
+        shininess = materials[hit.matIndex].n;
+    }
+    else
+    {
+        shininess = 5;  // default value
+    }
 
     if (hitDistance < 1.#INF)
     {
@@ -62,8 +76,9 @@ float3 Shade(
         
         for(int d = 0; d < numOfDirLight; d++)
         {
+
             tempColor  =   PhongDiffuseShading(dirLights[d].direction, dirLights[d].color, hit.normal) 
-                         + PhongSpecularShading(dirLights[d].direction, dirLights[d].color, ray.direction, hit.normal, 5);
+                         + PhongSpecularShading(dirLights[d].direction, dirLights[d].color, ray.direction, hit.normal, shininess);
             
             visibility = HardShadow(hit.position, 0, dirLights[d].direction, dirLights[d].direction, 
                                               hit.geoIndex, numOfSphere, spheres, numOfTriangle, triangles); 
@@ -74,7 +89,7 @@ float3 Shade(
         {
             float3 L = normalize(pointLights[p].position - hit.position);
             tempColor =   PhongDiffuseShading(L, pointLights[p].color, hit.normal) 
-                        + PhongSpecularShading(L, pointLights[p].color, ray.direction, hit.normal, 5);
+                        + PhongSpecularShading(L, pointLights[p].color, ray.direction, hit.normal, shininess);
             
             visibility = HardShadow(hit.position, 1, pointLights[p].position, pointLights[p].position,
                                               hit.geoIndex, numOfSphere, spheres, numOfTriangle, triangles);
@@ -104,7 +119,7 @@ float3 Shade(
             if(intensity > 0)
             {
                 tempColor = intensity * (PhongDiffuseShading(L, spotLights[s].color, hit.normal)
-                            + PhongSpecularShading(L, spotLights[s].color, ray.direction, hit.normal, 1)
+                            + PhongSpecularShading(L, spotLights[s].color, ray.direction, hit.normal, shininess)
                             );
                 
                 // check is shadow map is trued on

--- a/Final Project/Assets/RenderPipeline/Shading/Phong.compute
+++ b/Final Project/Assets/RenderPipeline/Shading/Phong.compute
@@ -54,8 +54,9 @@ float3 Shade(
     float hitDistance = hit.distance;
 
     // Example of how to retrieve material info
-    RTMaterial mat = GetIndexedMaterial(hit.matIndex,
-        numOfMaterials, materials);
+    RTMaterial mat = GetIndexedMaterial(materials,
+        numOfMaterials,
+        hit.matIndex);
     float shininess = mat.n;
 
     if (hitDistance < 1.#INF)

--- a/Final Project/Assets/Renderer/RTRenderer.cs
+++ b/Final Project/Assets/Renderer/RTRenderer.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 public class RTRenderer : MonoBehaviour
 {
-    [SerializeField] protected int m_materialIndex = -1;
+    //[SerializeField] protected int m_materialIndex = -1;
     // [SerializeField] protected int m_materialName = -1;  // TODO
 
     protected RTGeometry m_geom = null;
@@ -47,29 +47,6 @@ public class RTRenderer : MonoBehaviour
             }
 
             return m_geom.GetGeometryType();
-        }
-    }
-
-    /// <summary>
-    /// This returns material type struct for renderer
-    /// </summary>
-    /// <returns>material type struct</returns>
-    public RTMaterial Material
-    {
-        get
-        {
-            if (m_materialDatabase == null)
-            {
-                return new RTMaterial();
-            }
-
-            if (m_materialIndex < 0
-                || m_materialIndex > m_materialDatabase.Materials.Length - 1)
-            {
-                return new RTMaterial();
-            }
-
-            return m_materialDatabase.Materials[m_materialIndex];
         }
     }
 }

--- a/Final Project/Assets/Renderer/RTSphereRenderer.cs
+++ b/Final Project/Assets/Renderer/RTSphereRenderer.cs
@@ -31,6 +31,11 @@ public class RTSphereRenderer : RTRenderer
         }
     }
 
+    public RTSphere GetSphere()
+    {
+        return mySphere;
+    }
+
     /// <summary>
     /// Get RTSphere_t geometry for attached RTSphere component
     /// </summary>

--- a/Final Project/Assets/Renderer/RTTriangleRenderer.cs
+++ b/Final Project/Assets/Renderer/RTTriangleRenderer.cs
@@ -22,6 +22,11 @@ public class RTTriangleRenderer : RTRenderer
             return (RTTriangle)m_geom;
         }
     }
+
+    public RTTriangle GetTriangle()
+    {
+        return myTriangle;
+    }
     
     public RTTriangle_t GetGeometry()
     {

--- a/Final Project/Assets/SceneResourceSupport/Materials/RTMaterial.cs
+++ b/Final Project/Assets/SceneResourceSupport/Materials/RTMaterial.cs
@@ -4,19 +4,44 @@ using UnityEngine;
 
 public class RTMaterial : MonoBehaviour
 {   
-    // [SerializeField] private string m_MaterialName;  // TODO
+    [SerializeField] private string m_name;
     
     // classic Ambient, Diffuse, Specular
     [SerializeField] private Vector3 m_ka, m_ks, m_kd;
-    [SerializeField] Vector3 m_n;
+    [SerializeField] private Vector3 m_n;
 
     // support for transparency and refractiveIndex
-    [SerializeField] float m_transparency;
-    [SerializeField] float m_refractiveIndex; 
+    [SerializeField] private float m_transparency;
+    [SerializeField] private float m_refractiveIndex; 
 
     // support for reflection
-    [SerializeField] float m_reflectivity;
+    [SerializeField] private float m_reflectivity;
     
     // support for normal and positional map
-    [SerializeField] Vector3 m_normal, m_position;
+    [SerializeField] private Vector3 m_normal, m_position;
+
+    public string GetName()
+    {
+        return m_name;
+    }
+
+    public RTMaterial_t GetMaterial()
+    {
+        return new RTMaterial_t 
+        {
+            // classic Ambient, Diffuse, Specular
+            ka = m_ka, ks = m_ks, kd = m_kd,
+            n = m_n,
+
+            // support for transparency and refractiveIndex
+            transparency = m_transparency,
+            refractiveIndex = m_refractiveIndex,
+
+            // support for reflection
+            reflectivity = m_reflectivity,
+            
+            // support for normal and positional map
+            normal = m_normal, position = m_position
+        };
+    }
 }

--- a/Final Project/Assets/SceneResourceSupport/Materials/RTMaterial.cs
+++ b/Final Project/Assets/SceneResourceSupport/Materials/RTMaterial.cs
@@ -8,7 +8,7 @@ public class RTMaterial : MonoBehaviour
     
     // classic Ambient, Diffuse, Specular
     [SerializeField] private Vector3 m_ka, m_ks, m_kd;
-    [SerializeField] private Vector3 m_n;
+    [SerializeField] private float m_n;
 
     // support for transparency and refractiveIndex
     [SerializeField] private float m_transparency;

--- a/Final Project/Assets/SceneResourceSupport/Materials/RTMaterialDatabase.cs
+++ b/Final Project/Assets/SceneResourceSupport/Materials/RTMaterialDatabase.cs
@@ -15,11 +15,10 @@ public class RTMaterialDatabase : MonoBehaviour
     /// This returns material type struct for renderer
     /// </summary>
     /// <returns>material type struct</returns>
-    public RTMaterial[] Materials
+    public List<RTMaterial> GetMaterials()
     {
-        get
-        {
-            return m_materials;
-        }
+        return m_materials == null
+            ? null
+            : new List<RTMaterial>(m_materials);
     }
 }

--- a/Final Project/Assets/SceneResourceSupport/Materials/RTMaterialDatabase.cs
+++ b/Final Project/Assets/SceneResourceSupport/Materials/RTMaterialDatabase.cs
@@ -6,17 +6,17 @@ public class RTMaterialDatabase : MonoBehaviour
 {
     private RTMaterial[] m_materials = null;
 
-    private void Awake()
-    {
-        m_materials = GetComponents<RTMaterial>();
-    }
-
     /// <summary>
     /// This returns material type struct for renderer
     /// </summary>
     /// <returns>material type struct</returns>
     public List<RTMaterial> GetMaterials()
     {
+        if (m_materials == null)
+        {
+            m_materials = GetComponents<RTMaterial>();
+        }
+
         return m_materials == null
             ? null
             : new List<RTMaterial>(m_materials);

--- a/Final Project/Assets/SceneResourceSupport/Materials/RTMaterialStructure.cs
+++ b/Final Project/Assets/SceneResourceSupport/Materials/RTMaterialStructure.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public struct RTMaterial_t
+{
+    public int id;
+
+    // classic Ambient, Diffuse, Specular
+    public Vector3 ka, ks, kd;
+    public Vector3 n;
+
+    // support for transparency and refractiveIndex
+    public float transparency;
+    public float refractiveIndex; 
+
+    // support for reflection
+    public float reflectivity;
+    
+    // support for normal and positional map
+    public Vector3 normal, position;
+
+    public static int GetSize()
+    {
+        return sizeof(int)
+            + Vector3Extension.SizeOf() * 6
+            + sizeof(float) * 3;
+    }
+}

--- a/Final Project/Assets/SceneResourceSupport/Materials/RTMaterialStructure.cs
+++ b/Final Project/Assets/SceneResourceSupport/Materials/RTMaterialStructure.cs
@@ -8,7 +8,7 @@ public struct RTMaterial_t
 
     // classic Ambient, Diffuse, Specular
     public Vector3 ka, ks, kd;
-    public Vector3 n;
+    public float n;
 
     // support for transparency and refractiveIndex
     public float transparency;
@@ -23,7 +23,7 @@ public struct RTMaterial_t
     public static int GetSize()
     {
         return sizeof(int)
-            + Vector3Extension.SizeOf() * 6
-            + sizeof(float) * 3;
+            + Vector3Extension.SizeOf() * 5
+            + sizeof(float) * 4;
     }
 }

--- a/Final Project/Assets/SceneResourceSupport/Materials/RTMaterialStructure.cs.meta
+++ b/Final Project/Assets/SceneResourceSupport/Materials/RTMaterialStructure.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b4137ebc6fc52b54abbb93772265fb84
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Final Project/Assets/Scenes/AndrewScene.unity
+++ b/Final Project/Assets/Scenes/AndrewScene.unity
@@ -112,6 +112,95 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &839076789
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 839076793}
+  - component: {fileID: 839076792}
+  - component: {fileID: 839076791}
+  - component: {fileID: 839076790}
+  m_Layer: 0
+  m_Name: MyMaterialDatabase
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &839076790
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 839076789}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 12715149fa0fd044a9e13e2de7f7ee09, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_name: 
+  m_ka: {x: 0, y: 0, z: 0}
+  m_ks: {x: 0, y: 0, z: 0}
+  m_kd: {x: 0, y: 0, z: 0}
+  m_n: 0
+  m_transparency: 0
+  m_refractiveIndex: 0
+  m_reflectivity: 0
+  m_normal: {x: 0, y: 0, z: 0}
+  m_position: {x: 0, y: 0, z: 0}
+--- !u!114 &839076791
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 839076789}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 12715149fa0fd044a9e13e2de7f7ee09, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_name: 
+  m_ka: {x: 0, y: 0, z: 0}
+  m_ks: {x: 0, y: 0, z: 0}
+  m_kd: {x: 0, y: 0, z: 0}
+  m_n: 0
+  m_transparency: 0
+  m_refractiveIndex: 0
+  m_reflectivity: 0
+  m_normal: {x: 0, y: 0, z: 0}
+  m_position: {x: 0, y: 0, z: 0}
+--- !u!114 &839076792
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 839076789}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e564d2b8d8eddae4ba52867d45e427e1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &839076793
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 839076789}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.4165735, y: -1.4549222, z: 9.251701}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1534464891
 GameObject:
   m_ObjectHideFlags: 0
@@ -142,7 +231,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a707b232e61a247379604c2635881a1e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_materialIndex: -1
 --- !u!114 &1534464893
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -156,6 +244,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_radius: 1
+  m_materialName: 
 --- !u!4 &1534464894
 Transform:
   m_ObjectHideFlags: 0
@@ -168,7 +257,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1737745659
 GameObject:
@@ -251,93 +340,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2011548449
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2011548453}
-  - component: {fileID: 2011548452}
-  - component: {fileID: 2011548451}
-  - component: {fileID: 2011548450}
-  m_Layer: 0
-  m_Name: MyMaterialDatabase
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &2011548450
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2011548449}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 12715149fa0fd044a9e13e2de7f7ee09, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_ka: {x: 0, y: 0, z: 0}
-  m_ks: {x: 0, y: 0, z: 0}
-  m_kd: {x: 0, y: 0, z: 0}
-  m_n: {x: 0, y: 0, z: 0}
-  m_transparency: 0
-  m_refractiveIndex: 0
-  m_reflectivity: 0
-  m_normal: {x: 0, y: 0, z: 0}
-  m_position: {x: 0, y: 0, z: 0}
---- !u!114 &2011548451
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2011548449}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 12715149fa0fd044a9e13e2de7f7ee09, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_ka: {x: 0, y: 0, z: 0}
-  m_ks: {x: 0, y: 0, z: 0}
-  m_kd: {x: 0, y: 0, z: 0}
-  m_n: {x: 0, y: 0, z: 0}
-  m_transparency: 0
-  m_refractiveIndex: 0
-  m_reflectivity: 0
-  m_normal: {x: 0, y: 0, z: 0}
-  m_position: {x: 0, y: 0, z: 0}
---- !u!114 &2011548452
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2011548449}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e564d2b8d8eddae4ba52867d45e427e1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!4 &2011548453
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2011548449}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.51790047, y: 2.2281942, z: -0.6008086}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2138853565
 GameObject:


### PR DESCRIPTION
Tested with all scenes.  No graphic glitches or unusual behavior.

To use material parsing
(1) Like in AndrewScene, add MaterialDatabase with Material objects.  Give them values. Name them uniquely.
(2) Modify your shapes to Name the material they will use.

Need compute shader integration
(1) Already I added _NumOfMaterials and _Materials as parameters to compute functions.
(2) Already I added example how to use this:

    // Example of how to retrieve material info
    RTMaterial mat = GetIndexedMaterial(hit.matIndex,
        numOfMaterials, materials);
    float shininess = mat.n;