### PR TITLE
[Shading] fix specular shading when shinyness is 0

### DIFF
--- a/Final Project/Assets/RenderPipeline/Shading/Phong.compute
+++ b/Final Project/Assets/RenderPipeline/Shading/Phong.compute
@@ -21,7 +21,7 @@ float3 PhongSpecularShading(float3 lightDir, float3 lightColor, float3 rayDir, f
     float vDotR = dot(-1 * rayDir, R);
     if(vDotR < 0)
     {
-        vDotR = 0;
+        return float3(0, 0, 0);
     }
     return pow(vDotR, shinyness) * lightColor;
 }
@@ -63,7 +63,7 @@ float3 Shade(
         for(int d = 0; d < numOfDirLight; d++)
         {
             tempColor  =   PhongDiffuseShading(dirLights[d].direction, dirLights[d].color, hit.normal) 
-                         + PhongSpecularShading(dirLights[d].direction, dirLights[d].color, ray.direction, hit.normal, 5);
+                         + PhongSpecularShading(dirLights[d].direction, dirLights[d].color, ray.direction, hit.normal, 1);
             
             visibility = HardShadow(hit.position, 0, dirLights[d].direction, dirLights[d].direction, 
                                               hit.geoIndex, numOfSphere, spheres, numOfTriangle, triangles); 
@@ -74,7 +74,7 @@ float3 Shade(
         {
             float3 L = normalize(pointLights[p].position - hit.position);
             tempColor =   PhongDiffuseShading(L, pointLights[p].color, hit.normal) 
-                        + PhongSpecularShading(L, pointLights[p].color, ray.direction, hit.normal, 5);
+                        + PhongSpecularShading(L, pointLights[p].color, ray.direction, hit.normal, 1);
             
             visibility = HardShadow(hit.position, 1, pointLights[p].position, pointLights[p].position,
                                               hit.geoIndex, numOfSphere, spheres, numOfTriangle, triangles);


### PR DESCRIPTION
When V dot R is < 0, we set it to 0.
However, (V dot R) ^ n, n = 0, 0^0 = 1, which cause wrong shading.